### PR TITLE
Fixed typo and removed double slashes from diagnostics uri

### DIFF
--- a/server/diagnostics.jai
+++ b/server/diagnostics.jai
@@ -77,6 +77,7 @@ run_diagnostics :: () {
         ok: bool;
         location: string;
         ok, file, location = split_from_right(rest, ":");
+        file = replace(file, "\/\/", "\/",, temp);
         if !ok continue;
 
         line_and_character := split(location, ",");
@@ -89,7 +90,7 @@ run_diagnostics :: () {
         if !c_ok continue;
 
         diagnostic.message = message;
-        diagnostic.serverity = xx LSP_Diagnostic_Severity.ERROR;
+        diagnostic.severity = xx LSP_Diagnostic_Severity.ERROR;
 
         diagnostic.range.start.line = line-1;
         diagnostic.range.start.character = character-1;

--- a/server/lsp_interface.jai
+++ b/server/lsp_interface.jai
@@ -242,8 +242,8 @@ LSP_Publish_Diagnostics :: struct {
 
 LSP_Diagnostic :: struct {
     range: LSP_Range;
-    serverity: s64; // *LSP_Diagnostic_Severity;
     // code: *string; // @NOTE: potentionaly int
+    severity: s64; // *LSP_Diagnostic_Severity;
     // codeDescription: LSP_Code_Description;
     // source: *string;
     message: string;


### PR DESCRIPTION
This change should make it so that Lsp-mode + Flycheck on Emacs report errors correctly inside the editor.