### PR TITLE
deduplicate goto entries

### DIFF
--- a/server/program.jai
+++ b/server/program.jai
@@ -649,7 +649,18 @@ get_declarations_from_parent :: (decls: *[..]*Declaration, node: *Node, from_loc
                             add_decl = false;
                         }
 
-                        if add_decl array_add(decls, decl);
+                        if add_decl {
+                            for decls.* {
+                                if it == decl {
+                                    add_decl = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if add_decl {
+                            array_add(decls, decl);
+                        }
                 }
 
             }


### PR DESCRIPTION
For some reason sometimes I get duplicate entries returned when I try to go to definition. Change ensures that duplicates are not present. I suppose this should be enough for the time being as I wouldn't expect many declarations to show up anyway, so the checks shouldn't take that much time, and if they do we could swap the implementation for a Hash_Table.

<img width="1922" height="831" alt="image" src="https://github.com/user-attachments/assets/5504ac71-9833-4016-8ce2-b431e48f0531" />
