### PR TITLE
Completions for Struct Literals

### DIFF
--- a/server/completition.jai
+++ b/server/completition.jai
@@ -28,7 +28,7 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
             return;
         }
 
-        if cursor_node.kind == Node.Kind.COMMENT _exit();
+        if cursor_node.kind == Node.Kind.COMMENT return;
 
         if cursor_node.kind == .DIRECTIVE_IMPORT {
             handle_completitions_import(request, xx cursor_node);
@@ -38,7 +38,8 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
         // We don't wanna to give completions inside strings and comments...
         if cursor_node.kind == .LITERAL {
             if handle_completions_struct(request, cursor_node) == false {
-                _exit(); // Exit here. We're a literal but not a struct, so we can't provide completions
+                lsp_respond(request.id, null);
+                return; // Exit here. We're a literal but not a struct, so we can't provide completions
             }
 
             return;
@@ -71,7 +72,7 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
     }
 
     // General
-    decls = get_declarations(file, cursor_node, *cursor_location);
+    decls := get_declarations(file, cursor_node, *cursor_location);
 
     send_completions_decls(request, decls, should_add_basic_keywords=true);
 }

--- a/server/completition.jai
+++ b/server/completition.jai
@@ -28,8 +28,19 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
             return;
         }
 
+        if cursor_node.kind == Node.Kind.COMMENT _exit();
+
         if cursor_node.kind == .DIRECTIVE_IMPORT {
             handle_completitions_import(request, xx cursor_node);
+            return;
+        }
+        
+        // We don't wanna to give completions inside strings and comments...
+        if cursor_node.kind == .LITERAL {
+            if handle_completions_struct(request, cursor_node) == false {
+                _exit(); // Exit here. We're a literal but not a struct, so we can't provide completions
+            }
+
             return;
         }
 
@@ -60,8 +71,46 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
     }
 
     // General
-    decls := get_declarations(file, cursor_node, *cursor_location);
+    decls = get_declarations(file, cursor_node, *cursor_location);
+
     send_completions_decls(request, decls, should_add_basic_keywords=true);
+}
+
+handle_completions_struct::(request:LSP_Request_Message_Completion, node:*Node) -> bool {
+    literal := cast(*Literal)node;
+    if literal.value_type == .STRUCT {
+        // TODO: Infer the type for .{} structs literals... right now, assume struct_literal_info.type == null as undeterminable for completions.
+        if !literal.struct_literal_info.type || literal.struct_literal_info.type.kind != .IDENTIFIER {
+            return false;
+        }
+
+        identifier_decls := get_identifier_decls(cast(*Identifier) literal.struct_literal_info.type);
+        if identifier_decls.count == 0 {
+            return false;
+        }
+        
+        struct_decl := identifier_decls[0];
+        
+        if struct_decl.expression == null {
+            return false;
+        }
+
+        _struct := cast(*Struct) struct_decl.expression;
+
+        block := get_block_of(_struct);
+
+        if block == null {
+            return false;
+        }
+
+        decls := get_block_member_declarations(block);
+        
+        send_completions_decls(request, decls);
+
+        return true;
+    }
+
+    return false;
 }
 
 // handle_completitions_procedure_call :: (request: LSP_Request_Message_Completion, file: *Program_File, cursor_node: *Node, cursor_location: *Node.Location) -> bool {

--- a/server/goto.jai
+++ b/server/goto.jai
@@ -220,6 +220,10 @@ handle_procedure_call_goto :: (request: LSP_Request_Message_Definition, ident: *
 
     proc_call := cast(*Procedure_Call) ident.parent;
 
+    if proc_call.procedure != ident {
+        return false;
+    }
+
     decls := get_identifier_decls(ident);
     if decls.count == 0 {
         return false;

--- a/server/goto.jai
+++ b/server/goto.jai
@@ -220,10 +220,6 @@ handle_procedure_call_goto :: (request: LSP_Request_Message_Definition, ident: *
 
     proc_call := cast(*Procedure_Call) ident.parent;
 
-    if proc_call.procedure != ident {
-        return false;
-    }
-
     decls := get_identifier_decls(ident);
     if decls.count == 0 {
         return false;

--- a/server/program.jai
+++ b/server/program.jai
@@ -1383,6 +1383,50 @@ get_block_member :: (block: *Block, ident: *Identifier) -> *Declaration {
     return null;
 }
 
+get_block_member_declarations :: (block: *Block) -> []*Declaration {
+    decls:[..]*Declaration;
+    
+    for member: block.members {
+        if member.kind == {
+            case .IDENTIFIER;
+                _ident := cast(*Identifier) member;
+                if _ident {
+                    decl := New(Declaration); // @MEMORY: We should free this or it is temp?
+                    decl.name = _ident.name;
+                    decl.expression = *empty_identifier;
+                    decl.location = _ident.location;
+                    decl.const = true;
+
+                    array_add(*decls, decl);
+                }
+            case .DECLARATION;
+                decl := cast(*Declaration) member;
+                if decl {
+                    array_add(*decls, decl);
+                }
+
+            case .DIRECTIVE_AS; #through;
+            case .USING;
+                used_expression := get_used_expression(member);
+                if !used_expression || used_expression.kind != .DECLARATION && used_expression.kind != .IDENTIFIER {
+                    continue;
+                }
+
+                used_type := get_node_type(used_expression);
+                block := get_block_of(used_type);
+
+                if block {
+                    results :=get_block_member_declarations(block);
+                    for result:results {
+                        array_add(*decls,result);
+                    }
+                }
+        }
+    }
+
+    return decls;
+}
+
 unwrap_as :: (node: *Node) -> *Node {
     if !node return null;
 


### PR DESCRIPTION
Preface:
Completions checked with the following struct setup:
```
Heal_Effect::struct {
    amount:s32;
}

Ability::struct {
    effects:[]Effect;
}

Valx::struct {
    using heal:Heal_Effect;
    flt:float;
    ability:Ability;
}

Card::struct {
    #as using valx:Valx;
    name:string;
    effect_text:string;
    targeting_strategy:Targeting_Strategy;
}
```

Completions provide all expected values using VSCode's `ctrl-space` within the struct literal.
The using statement is recursive, and catches variables declared in Heal_Effect.

The only thing I believe is not working is type-infering the struct literal. IE, this provides correct completions:

```
card:= Card.{

};
```

This does not:
```
card:Card= .{
};
```

This is my first work ever done on an LSP, so please let me know if any changes are necessary. I'm also ok with this just not being the direction to take and closing the PR as a result, it was mostly me learning how LSPs work, and Jails in particular, while trying to solve a problem I have.