### PR TITLE
Symbols from local modules

### DIFF
--- a/server/main.jai
+++ b/server/main.jai
@@ -11,6 +11,7 @@ Args :: struct {
 
 User_Options :: struct {
     auto_insert_parentheses: bool;
+    use_symbols_from_local_modules: bool;
 }
 
 Server :: struct {
@@ -176,6 +177,7 @@ load_config_file :: () {
         jai_path: string;
         intermediate_path: string;
         auto_insert_parentheses := true;
+        use_symbols_from_local_modules := true;
     }
 
     config_path := join(server.project_root, "/jails.json");
@@ -202,6 +204,7 @@ load_config_file :: () {
     server.build_root = config.build_root;
     server.intermediate_path = config.intermediate_path;
     server.user_options.auto_insert_parentheses = config.auto_insert_parentheses;
+    server.user_options.use_symbols_from_local_modules = config.use_symbols_from_local_modules;
 
     if config.jai_path.count > 0 {
         server.args.jai_path = config.jai_path;

--- a/server/symbols.jai
+++ b/server/symbols.jai
@@ -41,15 +41,16 @@ handle_workspace_symbol :: (request: LSP_Request_Message_Workspace_Symbol) {
             continue;
         }
 
-        /*
-        // Skip files from local modules (we only want workspace project files)
-        for local_module_folder: server.local_modules {
-            full_local_module_folder_path := tprint("%/%", server.project_root, local_module_folder);
+        if !server.user_options.use_symbols_from_local_modules {
+            // Skip files from local modules (we only want workspace project files)
+            for local_module_folder: server.local_modules {
+                full_local_module_folder_path := tprint("%/%", server.project_root, local_module_folder);
 
-            if begins_with(file.path, full_local_module_folder_path) {
-                continue file;
+                if begins_with(file.path, full_local_module_folder_path) {
+                    continue file;
+                }
             }
-        }*/
+        }
 
         symbols: [..]LSP_Document_Symbol;
         load_symbols_from_file(file, *symbols);


### PR DESCRIPTION
Uncommented the section that removes local modules symbols from "Go to symbol in Workspace" (ie. Ctrl+T) and added option "use_symbols_from_local_modules" to jails.json (defaults to true which I believe is the correct behavior).
