### PR TITLE
Supports union completion in structs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,10 +6,10 @@
         {
             "label": "build",
             "type": "shell",
-            "command": "jai ${workspaceFolder}/build.jai - -vscode",
+            "command": "jai ${workspaceFolder}/build.jai",
             "presentation": {
                 "echo": true,
-                "reveal": "silent",
+                "reveal": "always",
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": true,
@@ -17,8 +17,22 @@
             },
             "group": {
                 "kind": "build",
-                "isDefault": true,
+                "isDefault": true
             }
         },
+        {
+            "label": "run extension",
+            "type": "shell",
+            "command": "jai ${workspaceFolder}/build.jai - -vscode",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        }
     ]
 }

--- a/build.jai
+++ b/build.jai
@@ -26,6 +26,12 @@
         options.output_path = "./bin";
         options.import_path = import_path;
 
+        if !release {
+            // Use the X64 backend and natvis type for the best vscode debug experience
+            options.backend = .X64;
+            options.use_natvis_compatible_types = true;
+        }
+
         if release set_optimization(*options, .VERY_OPTIMIZED);
         if very_debug set_optimization(*options, .VERY_DEBUG);
 

--- a/server/program.jai
+++ b/server/program.jai
@@ -471,6 +471,9 @@ add_all_fields_of :: (decls: *[..]*Declaration, node: *Node, filter_name: string
                 decl := cast(*Declaration) member;
                 if !filter_name || filter_name == decl.name array_add(decls, decl);
 
+            case .UNION;
+                add_all_fields_of(decls, member);
+            
             case .COMPOUND_DECLARATION;
                 compound_declaration_to_declarations(decls, cast(*Compound_Declaration) member, filter_name);
 
@@ -1307,6 +1310,10 @@ get_block_member_type :: (block: *Block, ident: *Identifier, solve_array := fals
 get_block_member :: (block: *Block, ident: *Identifier) -> *Declaration {
     for member: block.members {
         if member.kind == {
+            case .UNION;
+                _union := cast(*Union)member;
+
+                return get_block_member(_union.block, ident);
             case .IDENTIFIER;
                 _ident := cast(*Identifier) member;
                 if _ident.name == ident.name {


### PR DESCRIPTION
Now supports unions in struct, so it correctly autocompletes something like:

```
Light :: struct {
    type: LightType;
    union {
        point: struct {
            position: Vec3f;
            color: Vec3f;
            intensity: float;
            range: float;
        }
        spot: struct {
            position: Vec3f;
            color: Vec3f;
            intensity: float;
            range: float;
            direction: Vec3f;
            inner_cone: float;
            outer_cone: float;
        }
    }
}

```
<img width="1072" height="250" alt="image" src="https://github.com/user-attachments/assets/1c994dab-23b3-4eca-902f-9e033d38d5d6" />

NOTE: I've also tweaked the build file to output natvis compatible types with the X64 backend in debug to improve the debug experience with proper arrays, strings etc support.



