### PR TITLE
Fix double slash highlighting for comment

### DIFF
--- a/vscode_extension/syntaxes/jai.tmLanguage.json
+++ b/vscode_extension/syntaxes/jai.tmLanguage.json
@@ -576,7 +576,7 @@
 					"match": "(//)(.*)",
 					"captures": {
 						"1": {
-							"name": "punctuation.definition.comment.jai"
+							"name": "comment.line.double-slash.jai"
 						},
 						"2": {
 							"name": "comment.line.double-slash.jai",


### PR DESCRIPTION
The same PR was made here https://github.com/onelivesleft/the-language/pull/11, it just took a long time to get merged (but did eventually). Likely got merged after the tmLanguage file got copied from the other repo

Before:
<img width="909" height="339" alt="image" src="https://github.com/user-attachments/assets/e7557be4-90e2-4f6c-a512-eb3d7096aec6" />

After:
<img width="883" height="331" alt="image" src="https://github.com/user-attachments/assets/3a0181d3-cab1-4d45-bc91-7954df75bcca" />
