### PR TITLE
Rename and hover

### DIFF
--- a/server/goto.jai
+++ b/server/goto.jai
@@ -29,228 +29,55 @@ handle_goto_import :: (request: LSP_Request_Message_Definition, file: *Program_F
 }
 
 handle_goto_dot :: (request: LSP_Request_Message_Definition, ident: *Identifier) -> bool {
-    if !ident || !ident.parent return false;
+    if !ident return false;
 
-    leaf_node: *Node;
-    op: *Binary_Operation;
+    decls, matched := resolve_dot_member(ident);
+    if !matched return false;
 
-    if ident.parent.kind == {
-        case .BINARY_OPERATION;
-            op = cast(*Binary_Operation) ident.parent;
-            leaf_node = ident;
-
-        case .ARRAY_SUBSCRIPT;
-            array_subscript := cast(*Array_Subscript) ident.parent;
-            if array_subscript.parent && array_subscript.parent.kind == .BINARY_OPERATION {
-                op = cast(*Binary_Operation) array_subscript.parent;
-                leaf_node = array_subscript;
-            }
-
-        case .PROCEDURE_CALL;
-            proc_call := cast(*Procedure_Call) ident.parent;
-            if proc_call.parent && proc_call.parent.kind == .BINARY_OPERATION {
-                op = cast(*Binary_Operation) proc_call.parent;
-                leaf_node = proc_call;
-            }
-
-        // @TODO: anything else?
-    }
-
-    if !op {
-        return false;
-    }
-
-    path := get_dot_path(op, leaf_node);
-    if path.count < 2 {
-        return false;
-    }
-
-    path = array_view(path, 0, path.count-1);
-
-    type := get_path_type(path);
-    if !type {
+    if decls.count == 0 {
         lsp_respond(request.id, null);
         return true;
     }
 
-    decl := get_member_in(type, ident);
-    if !decl {
-        lsp_respond(request.id, null);
-        return true;
-    }
-
-    lsp_respond(request.id, node_location_to_lsp_location(decl.location));
+    lsp_respond(request.id, node_location_to_lsp_location(decls[0].location));
     return true;
 }
 
 handle_goto_procedure_named_argument :: (request: LSP_Request_Message_Definition, file: *Program_File, ident: *Identifier) -> bool {
-    if !ident.parent || ident.parent.kind != .BINARY_OPERATION {
-        return false;
-    }
+    decls, matched := resolve_procedure_named_argument(ident);
+    if !matched || decls.count == 0 return false;
 
-    binary_op := cast(*Binary_Operation) ident.parent;
-
-    // We only want to resolve this if its the left side.
-    if binary_op.right == ident {
-        return false;
-    }
-
-    if !binary_op.parent || binary_op.parent.kind != .PROCEDURE_CALL {
-        return false;
-    }
-
-    procedure_call := cast(*Procedure_Call) binary_op.parent;
-
-    if !procedure_call.procedure {
-        return false;
-    }
-
-    // We need to resolve the calle procedure.
-    decls := get_identifier_decls(cast(*Identifier) procedure_call.procedure);
-    if decls.count == 0 {
-        return false;
-    }
-
-    procedure_decl := decls[0]; // TODO: here we need to resolve procedure overloading in the future.
-    if !procedure_decl.expression {
-        return false;
-    }
-
-    procedure := cast(*Procedure) procedure_decl.expression;
-
-    for arg: procedure.arguments {
-        unwrapped_arg := unwrap_polymorphic_constant(arg);
-
-        // It should always be decl??
-        if unwrapped_arg.kind != .DECLARATION {
-            log("arg.kind: %", arg.kind);
-            continue;
-        }
-
-        arg_decl := cast(*Declaration) unwrapped_arg;
-
-        if arg_decl.name == ident.name {
-            lsp_respond(request.id, node_location_to_lsp_location(arg_decl.location));
-            return true;
-        }
-    }
-
-    return false;
+    lsp_respond(request.id, node_location_to_lsp_location(decls[0].location));
+    return true;
 }
 
 handle_goto_struct_literal :: (request: LSP_Request_Message_Definition, file: *Program_File, ident: *Identifier) -> bool {
-    if !ident.parent || ident.parent.kind != .BINARY_OPERATION {
-        return false;
-    }
+    decls, matched := resolve_struct_literal_field(ident);
+    if !matched || decls.count == 0 return false;
 
-    binary_op := cast(*Binary_Operation) ident.parent;
-
-    // We only want to resolve this if its the left side.
-    if binary_op.right == ident {
-        return false;
-    }
-
-    if !binary_op.parent || binary_op.parent.kind != .LITERAL {
-        return false;
-    }
-
-    literal := cast(*Literal) binary_op.parent;
-
-    // TODO: Infer the type for .{} structs literals...
-    if literal.value_type != .STRUCT || !literal.struct_literal_info.type || literal.struct_literal_info.type.kind != .IDENTIFIER {
-        return false;
-    }
-
-    // We need to resolve struct literal type.
-    decls := get_identifier_decls(cast(*Identifier) literal.struct_literal_info.type);
-    if decls.count == 0 {
-        return false;
-    }
-
-    struct_decl := decls[0];
-    if !struct_decl.expression {
-        return false;
-    }
-
-
-    _struct := cast(*Struct) struct_decl.expression;
-
-    decl := get_member_in(_struct, ident);
-    if !decl {
-        return false;
-    }
-
-    lsp_respond(request.id, node_location_to_lsp_location(decl.location));
+    lsp_respond(request.id, node_location_to_lsp_location(decls[0].location));
     return true;
 }
 
 handle_goto_assignment :: (request: LSP_Request_Message_Definition, ident: *Identifier) -> bool {
-    if !ident.parent || ident.parent.kind != .UNARY_OPERATION {
-        return false;
-    }
+    decls, matched := resolve_assignment_field(ident);
+    if !matched || decls.count == 0 return false;
 
-    unary_op := cast(*Unary_Operation, ident.parent);
-    if unary_op.operation != .DOT {
-        return false;
-    }
-
-    if !unary_op.parent || unary_op.parent.kind != .BINARY_OPERATION  {
-        return false;
-    }
-
-    binary_op_type := get_node_type(unary_op.parent, true);
-    if !binary_op_type {
-        return false;
-    }
-
-    decl := get_member_in(binary_op_type, ident);
-    if !decl {
-        return false;
-    }
-
-    lsp_respond(request.id, node_location_to_lsp_location(decl.location));
-
+    lsp_respond(request.id, node_location_to_lsp_location(decls[0].location));
     return true;
 }
 
 handle_procedure_call_goto :: (request: LSP_Request_Message_Definition, ident: *Identifier) -> bool {
-    if !ident.parent || ident.parent.kind != .PROCEDURE_CALL {
-        return false;
-    }
+    decls, matched := resolve_procedure_call_best(ident);
+    if !matched || decls.count == 0 return false;
 
-    proc_call := cast(*Procedure_Call) ident.parent;
+    proc_decl := decls[0];
+    type := get_node_type(proc_decl, stop_at_procedure=true);
+    if !type || type.kind != .PROCEDURE return false;
+    procedure := cast(*Procedure) type;
+    if !procedure.parent return false;
 
-    if proc_call.procedure != ident {
-        return false;
-    }
-
-    decls := get_identifier_decls(ident);
-    if decls.count == 0 {
-        return false;
-    }
-
-    procedures: [..]*Procedure;
-    for proc_decl: decls {
-        type := get_node_type(proc_decl, stop_at_procedure=true);
-        if !type || type.kind != .PROCEDURE {
-            remove proc_decl;
-            continue;
-        }
-
-        array_add(*procedures, cast(*Procedure) type);
-    }
-
-    if procedures.count == 0 {
-        return false;
-    }
-
-    best_override_index := get_best_overload_for_procedure_call(procedures, proc_call);
-
-    if !procedures[best_override_index].parent {
-        return false;
-    }
-
-    lsp_respond(request.id, node_location_to_lsp_location(procedures[best_override_index].parent.location));
+    lsp_respond(request.id, node_location_to_lsp_location(procedure.parent.location));
     return true;
 }
 

--- a/server/hover.jai
+++ b/server/hover.jai
@@ -1,48 +1,95 @@
-// handle_hover :: (request: LSP_Request_Message_Hover) {
-//     push_allocator(temp);
+handle_hover :: (request: LSP_Request_Message_Hover) {
+    push_allocator(temp);
 
-//     file_path := normalize_path(request.params.textDocument.uri);
+    file_path := normalize_path(request.params.textDocument.uri);
 
-//     file := get_file(file_path);
-//     if !file {
-//         lsp_respond(request.id, null);
-//         return;
-//     }
+    file := get_file(file_path);
+    if !file {
+        lsp_respond(request.id, null);
+        return;
+    }
 
-//     cursor_location := lsp_location_to_node_location(request.params.position, file_path);
-//     cursor_block := cast(*Block) get_node_by_location(file, cursor_location, .BLOCK);
-//     cursor_node := get_node_by_location(file, cursor_location);
+    cursor_location := lsp_location_to_node_location(request.params.position, file_path);
 
-//     if !cursor_node {
-//         lsp_respond(request.id, null);
-//         return;
-//     }
+    if inside_comment(cursor_location) {
+        lsp_respond(request.id, null);
+        return;
+    }
 
-//     if cursor_node.kind != .IDENTIFIER {
-//         lsp_respond(request.id, null);
-//         return;
-//     }
+    cursor_node := get_node_by_location(file, cursor_location);
+    if !cursor_node {
+        lsp_respond(request.id, null);
+        return;
+    }
 
-//     ident := cast(*Identifier) cursor_node;
+    target_decl: *Declaration;
 
-//     builder: String_Builder;
+    if cursor_node.kind == {
+        case .IDENTIFIER;
+            ident := cast(*Identifier) cursor_node;
+            decls := resolve_identifier_for_hover(ident);
+            if decls.count > 0 target_decl = decls[0];
 
-//     if ident.parent && ident.parent.kind == .BINARY_OPERATION {
-//         result := goto_dot_path_member(file, xx ident.parent, ident);
-//         if result {
-//             ast_print(*builder, result);
-//             lsp_respond(request.id, LSP_Hover.{ contents=builder_to_string(*builder) });
-//             return;
-//         }
-//     }
+        case .DECLARATION;
+            target_decl = cast(*Declaration) cursor_node;
+    }
 
-//     type := get_node_type(file, ident);
-//     if !type {
-//         lsp_respond(request.id, null);
-//         return;
-//     }
+    if !target_decl {
+        lsp_respond(request.id, null);
+        return;
+    }
 
+    builder: String_Builder;
+    append(*builder, "```jai\n");
+    append_decl_for_hover(*builder, target_decl);
+    append(*builder, "\n```");
 
-//     ast_print(*builder, type);
-//     lsp_respond(request.id, LSP_Hover.{ contents=builder_to_string(*builder) });
-// }
+    hover: LSP_Hover;
+    hover.contents.value = builder_to_string(*builder);
+    lsp_respond(request.id, hover);
+}
+
+append_decl_for_hover :: (builder: *String_Builder, decl: *Declaration) {
+    expr := decl.expression;
+    if expr && (expr.kind == .STRUCT || expr.kind == .ENUM || expr.kind == .UNION) {
+        if decl.backticked append(builder, #char "`");
+        append(builder, decl.name);
+        append(builder, " :: ");
+
+        if expr.kind == {
+            case .STRUCT; append(builder, "struct");
+            case .ENUM;   append(builder, "enum");
+            case .UNION;  append(builder, "union");
+        }
+
+        block := get_block_of(expr);
+        if block && block.members.count > 0 {
+            append(builder, " {\n");
+            for member: block.members {
+                append(builder, "    ");
+                ast_print(builder, member);
+                append(builder, ";\n");
+            }
+            append(builder, "}");
+        }
+
+        return;
+    }
+
+    if expr && expr.kind == .DIRECTIVE_TYPE {
+        directive_type := cast(*Directive_Type) expr;
+        if decl.backticked append(builder, #char "`");
+        append(builder, decl.name);
+        append(builder, " :: #type");
+        if directive_type.isa      append(builder, ",isa");
+        if directive_type.distinct append(builder, ",distinct");
+        if directive_type.expression {
+            append(builder, " ");
+            ast_print(builder, directive_type.expression);
+        }
+        return;
+    }
+
+    ast_print(builder, decl);
+}
+

--- a/server/lsp_interface.jai
+++ b/server/lsp_interface.jai
@@ -498,7 +498,7 @@ LSP_Result_Initialize :: struct {
 
         definitionProvider := true;
         renameProvider := true;
-        // hoverProvider := true;
+        hoverProvider := true;
 
         signatureHelpProvider: struct {
             triggerCharacters   := string.["("];
@@ -646,8 +646,10 @@ LSP_Completion_Item :: struct {
 }
 
 LSP_Hover :: struct {
-    contents: string;
-    contentFormat:= "markdown";
+    contents: struct {
+        kind := "markdown";
+        value: string;
+    }
 }
 
 LSP_Folding_Range_Client_Capabilities :: struct {

--- a/server/lsp_interface.jai
+++ b/server/lsp_interface.jai
@@ -497,6 +497,7 @@ LSP_Result_Initialize :: struct {
         workspaceSymbolProvider := true;
 
         definitionProvider := true;
+        renameProvider := true;
         // hoverProvider := true;
 
         signatureHelpProvider: struct {
@@ -544,6 +545,19 @@ LSP_Request_Message_Completion :: struct {
             triggerCharacter: string;
         } @JsonName(context)
     }
+}
+
+LSP_Request_Message_Rename :: struct {
+    using request: LSP_Request_Message;
+    params: struct {
+        textDocument: LSP_Text_Document_Identifier;
+        position: LSP_Position;
+        newName: string;
+    }
+}
+
+LSP_Rename_Result :: struct {
+    changes: JSON_Value;
 }
 
 LSP_Request_Message_Signature_Help :: struct {

--- a/server/main.jai
+++ b/server/main.jai
@@ -451,6 +451,15 @@ handle_request :: (request: LSP_Request_Message, raw_request: string) {
 
             handle_signature_help(body);
 
+        case "textDocument/rename";
+            success, body := json_parse_string(raw_request, LSP_Request_Message_Rename,, temp);
+            if !success {
+                log_error("Unable to parse textDocument/rename message");
+                return;
+            }
+
+            handle_rename(body);
+
         case "textDocument/hover";
             // success, body := json_parse_string(raw_request, LSP_Request_Message_Hover,, temp);
             // if !success {
@@ -542,10 +551,12 @@ main :: () {
 #load "memory_files.jai";
 
 #load "completition.jai";
+#load "resolve.jai";
 #load "goto.jai";
 #load "signature_help.jai";
 #load "hover.jai";
 #load "symbols.jai";
+#load "rename.jai";
 #load "utils.jai";
 
 #if OS == .WINDOWS {

--- a/server/main.jai
+++ b/server/main.jai
@@ -461,13 +461,13 @@ handle_request :: (request: LSP_Request_Message, raw_request: string) {
             handle_rename(body);
 
         case "textDocument/hover";
-            // success, body := json_parse_string(raw_request, LSP_Request_Message_Hover,, temp);
-            // if !success {
-            //     log_error("Unable to parse textDocument/completion message");
-            //     return;
-            // }
+            success, body := json_parse_string(raw_request, LSP_Request_Message_Hover,, temp);
+            if !success {
+                log_error("Unable to parse textDocument/hover message");
+                return;
+            }
 
-            // handle_hover(body);
+            handle_hover(body);
     }
 }
 

--- a/server/rename.jai
+++ b/server/rename.jai
@@ -1,0 +1,189 @@
+decl_name_range :: (decl: *Declaration) -> Node.Location {
+    name_length := decl.name.count;
+    if decl.backticked name_length += 2;
+
+    loc := decl.location;
+    loc.l1 = loc.l0;
+    loc.c1 = loc.c0 + name_length;
+    return loc;
+}
+
+rename_new_json_object :: () -> *JSON_Object {
+    return New(JSON_Object);
+}
+
+rename_json_number :: (n: int) -> JSON_Value {
+    return .{type=.NUMBER, number=cast(float64) n};
+}
+
+rename_json_string :: (s: string) -> JSON_Value {
+    return .{type=.STRING, str=s};
+}
+
+rename_json_object :: (obj: *JSON_Object) -> JSON_Value {
+    return .{type=.OBJECT, object=obj};
+}
+
+rename_json_array :: (arr: []JSON_Value) -> JSON_Value {
+    return .{type=.ARRAY, array=arr};
+}
+
+rename_position_to_json :: (line: int, character: int) -> JSON_Value {
+    obj := rename_new_json_object();
+    table_set(obj, "line", rename_json_number(line));
+    table_set(obj, "character", rename_json_number(character));
+    return rename_json_object(obj);
+}
+
+rename_range_to_json :: (loc: Node.Location) -> JSON_Value {
+    obj := rename_new_json_object();
+    table_set(obj, "start", rename_position_to_json(loc.l0, loc.c0));
+    table_set(obj, "end", rename_position_to_json(loc.l1, loc.c1));
+    return rename_json_object(obj);
+}
+
+rename_text_edit_to_json :: (loc: Node.Location, new_text: string) -> JSON_Value {
+    obj := rename_new_json_object();
+    table_set(obj, "range", rename_range_to_json(loc));
+    table_set(obj, "newText", rename_json_string(new_text));
+    return rename_json_object(obj);
+}
+
+Rename_Edit :: struct {
+    location: Node.Location;
+}
+
+handle_rename :: (request: LSP_Request_Message_Rename) {
+    push_allocator(temp);
+
+    new_name := trim(request.params.newName);
+    if new_name.count == 0 {
+        lsp_respond_with_error(request.id, .INVALID_PARAMS, "newName cannot be empty", "");
+        return;
+    }
+
+    file_path := normalize_path(request.params.textDocument.uri);
+
+    file := get_file(file_path);
+    if !file {
+        log_error("File does not exist or has not been parsed yet! (%)", file_path);
+        lsp_respond(request.id, null);
+        return;
+    }
+
+    cursor_location := lsp_location_to_node_location(request.params.position, file_path);
+    cursor_node := get_node_by_location(file, cursor_location);
+    if !cursor_node {
+        lsp_respond(request.id, null);
+        return;
+    }
+
+    target_name: string;
+    target_decls: [..]*Declaration;
+
+    if cursor_node.kind == {
+        case .IDENTIFIER;
+            ident := cast(*Identifier) cursor_node;
+            target_name = ident.name;
+            decls := resolve_identifier_for_rename(ident);
+            for decls array_add(*target_decls, it);
+
+        case .DECLARATION;
+            decl := cast(*Declaration) cursor_node;
+            if decl.name.count == 0 {
+                lsp_respond(request.id, null);
+                return;
+            }
+            target_name = decl.name;
+            array_add(*target_decls, decl);
+
+        case;
+            lsp_respond(request.id, null);
+            return;
+    }
+
+    if target_name.count == 0 {
+        lsp_respond(request.id, null);
+        return;
+    }
+
+    Edits_Per_File :: struct {
+        path: string;
+        locations: [..]Node.Location;
+    }
+
+    add_location :: (per_file: *Edits_Per_File, loc: Node.Location) {
+        for per_file.locations {
+            if it.l0 == loc.l0 && it.c0 == loc.c0 && it.l1 == loc.l1 && it.c1 == loc.c1 && it.file == loc.file {
+                return;
+            }
+        }
+        array_add(*per_file.locations, loc);
+    }
+
+    files_table: Table(string, *Edits_Per_File);
+
+    get_or_make :: (table: *Table(string, *Edits_Per_File), path: string) -> *Edits_Per_File {
+        ok, existing := table_find(table, path);
+        if ok return existing;
+
+        entry := New(Edits_Per_File);
+        entry.path = path;
+        table_add(table, path, entry);
+        return entry;
+    }
+
+    for target_decl: target_decls {
+        loc := decl_name_range(target_decl);
+        if loc.file.count == 0 continue;
+        entry := get_or_make(*files_table, loc.file);
+        add_location(entry, loc);
+    }
+
+    // @SPEED: walks every identifier in every parsed file and re-resolves each one.
+    for file_iter: server.files {
+        for node: file_iter.nodes {
+            if node.kind != .IDENTIFIER continue;
+
+            ident := cast(*Identifier) node;
+            if ident.name != target_name continue;
+
+            if ident.location.file.count == 0 continue;
+
+            decls := resolve_identifier_for_rename(ident);
+
+            matches: bool;
+            for decl: decls {
+                for target: target_decls {
+                    if decl == target {
+                        matches = true;
+                        break decl;
+                    }
+                }
+            }
+
+            if !matches continue;
+
+            entry := get_or_make(*files_table, ident.location.file);
+            add_location(entry, ident.location);
+        }
+    }
+
+    changes_obj := rename_new_json_object();
+
+    for entry: files_table {
+        if entry.locations.count == 0 continue;
+
+        edits_arr := NewArray(entry.locations.count, JSON_Value);
+        for entry.locations {
+            edits_arr[it_index] = rename_text_edit_to_json(it, new_name);
+        }
+
+        table_set(changes_obj, path_to_lsp_path(entry.path), rename_json_array(edits_arr));
+    }
+
+    result: LSP_Rename_Result;
+    result.changes = rename_json_object(changes_obj);
+
+    lsp_respond(request.id, result);
+}

--- a/server/resolve.jai
+++ b/server/resolve.jai
@@ -118,6 +118,7 @@ resolve_dot_member :: (ident: *Identifier) -> []*Declaration, bool {
     path = array_view(path, 0, path.count-1);
 
     type := get_path_type(path);
+    // @TODO: polymorphic return types — `proc(T, ...).x` doesn't resolve when proc returns *T or T.
     if !type return decls, true;
 
     decl := get_member_in(type, ident);
@@ -165,6 +166,25 @@ resolve_identifier_for_rename :: (ident: *Identifier) -> []*Declaration {
     if matched return decls;
 
     decls, matched = resolve_dot_member(ident);
+    if matched return decls;
+
+    return get_identifier_decls(ident);
+}
+
+resolve_identifier_for_hover :: (ident: *Identifier) -> []*Declaration {
+    decls, matched := resolve_procedure_named_argument(ident);
+    if matched return decls;
+
+    decls, matched = resolve_struct_literal_field(ident);
+    if matched return decls;
+
+    decls, matched = resolve_assignment_field(ident);
+    if matched return decls;
+
+    decls, matched = resolve_dot_member(ident);
+    if matched return decls;
+
+    decls, matched = resolve_procedure_call_best(ident);
     if matched return decls;
 
     return get_identifier_decls(ident);

--- a/server/resolve.jai
+++ b/server/resolve.jai
@@ -1,0 +1,171 @@
+resolve_procedure_named_argument :: (ident: *Identifier) -> []*Declaration, bool {
+    decls: [..]*Declaration;
+
+    if !ident.parent || ident.parent.kind != .BINARY_OPERATION return decls, false;
+
+    binary_op := cast(*Binary_Operation) ident.parent;
+    if binary_op.right == ident return decls, false;
+
+    if !binary_op.parent || binary_op.parent.kind != .PROCEDURE_CALL return decls, false;
+
+    procedure_call := cast(*Procedure_Call) binary_op.parent;
+    if !procedure_call.procedure || procedure_call.procedure.kind != .IDENTIFIER return decls, true;
+
+    proc_decls := get_identifier_decls(cast(*Identifier) procedure_call.procedure);
+
+    for proc_decl: proc_decls {
+        if !proc_decl.expression || proc_decl.expression.kind != .PROCEDURE continue;
+
+        procedure := cast(*Procedure) proc_decl.expression;
+
+        for arg: procedure.arguments {
+            unwrapped_arg := unwrap_polymorphic_constant(arg);
+            if unwrapped_arg.kind != .DECLARATION continue;
+
+            arg_decl := cast(*Declaration) unwrapped_arg;
+            if arg_decl.name == ident.name array_add(*decls, arg_decl);
+        }
+    }
+
+    return decls, true;
+}
+
+resolve_struct_literal_field :: (ident: *Identifier) -> []*Declaration, bool {
+    decls: [..]*Declaration;
+
+    if !ident.parent || ident.parent.kind != .BINARY_OPERATION return decls, false;
+
+    binary_op := cast(*Binary_Operation) ident.parent;
+    if binary_op.right == ident return decls, false;
+
+    if !binary_op.parent || binary_op.parent.kind != .LITERAL return decls, false;
+
+    literal := cast(*Literal) binary_op.parent;
+    // @TODO: Infer the type for .{} structs literals...
+    if literal.value_type != .STRUCT || !literal.struct_literal_info.type || literal.struct_literal_info.type.kind != .IDENTIFIER {
+        return decls, true;
+    }
+
+    type_decls := get_identifier_decls(cast(*Identifier) literal.struct_literal_info.type);
+    if type_decls.count == 0 return decls, true;
+
+    struct_decl := type_decls[0];
+    if !struct_decl.expression return decls, true;
+
+    _struct := cast(*Struct) struct_decl.expression;
+
+    decl := get_member_in(_struct, ident);
+    if decl array_add(*decls, decl);
+
+    return decls, true;
+}
+
+resolve_assignment_field :: (ident: *Identifier) -> []*Declaration, bool {
+    decls: [..]*Declaration;
+
+    if !ident.parent || ident.parent.kind != .UNARY_OPERATION return decls, false;
+
+    unary_op := cast(*Unary_Operation) ident.parent;
+    if unary_op.operation != .DOT return decls, false;
+
+    if !unary_op.parent || unary_op.parent.kind != .BINARY_OPERATION return decls, false;
+
+    binary_op_type := get_node_type(unary_op.parent, true);
+    if !binary_op_type return decls, true;
+
+    decl := get_member_in(binary_op_type, ident);
+    if decl array_add(*decls, decl);
+
+    return decls, true;
+}
+
+resolve_dot_member :: (ident: *Identifier) -> []*Declaration, bool {
+    decls: [..]*Declaration;
+
+    if !ident.parent return decls, false;
+
+    leaf_node: *Node;
+    op: *Binary_Operation;
+
+    if ident.parent.kind == {
+        case .BINARY_OPERATION;
+            op = cast(*Binary_Operation) ident.parent;
+            leaf_node = ident;
+
+        case .ARRAY_SUBSCRIPT;
+            array_subscript := cast(*Array_Subscript) ident.parent;
+            if array_subscript.parent && array_subscript.parent.kind == .BINARY_OPERATION {
+                op = cast(*Binary_Operation) array_subscript.parent;
+                leaf_node = array_subscript;
+            }
+
+        case .PROCEDURE_CALL;
+            proc_call := cast(*Procedure_Call) ident.parent;
+            if proc_call.parent && proc_call.parent.kind == .BINARY_OPERATION {
+                op = cast(*Binary_Operation) proc_call.parent;
+                leaf_node = proc_call;
+            }
+
+        // @TODO: anything else?
+    }
+
+    if !op return decls, false;
+    if op.operation != .DOT return decls, false;
+
+    path := get_dot_path(op, leaf_node);
+    if path.count < 2 return decls, false;
+
+    path = array_view(path, 0, path.count-1);
+
+    type := get_path_type(path);
+    if !type return decls, true;
+
+    decl := get_member_in(type, ident);
+    if decl array_add(*decls, decl);
+
+    return decls, true;
+}
+
+resolve_procedure_call_best :: (ident: *Identifier) -> []*Declaration, bool {
+    decls: [..]*Declaration;
+
+    if !ident.parent || ident.parent.kind != .PROCEDURE_CALL return decls, false;
+    proc_call := cast(*Procedure_Call) ident.parent;
+    if proc_call.procedure != ident return decls, false;
+
+    candidate_decls := get_identifier_decls(ident);
+    if candidate_decls.count == 0 return decls, true;
+
+    procedures: [..]*Procedure;
+    procedure_decls: [..]*Declaration;
+
+    for proc_decl: candidate_decls {
+        type := get_node_type(proc_decl, stop_at_procedure=true);
+        if !type || type.kind != .PROCEDURE continue;
+        array_add(*procedures, cast(*Procedure) type);
+        array_add(*procedure_decls, proc_decl);
+    }
+
+    if procedures.count == 0 return decls, true;
+
+    best := get_best_overload_for_procedure_call(procedures, proc_call);
+    array_add(*decls, procedure_decls[best]);
+
+    return decls, true;
+}
+
+resolve_identifier_for_rename :: (ident: *Identifier) -> []*Declaration {
+    decls, matched := resolve_procedure_named_argument(ident);
+    if matched return decls;
+
+    decls, matched = resolve_struct_literal_field(ident);
+    if matched return decls;
+
+    decls, matched = resolve_assignment_field(ident);
+    if matched return decls;
+
+    decls, matched = resolve_dot_member(ident);
+    if matched return decls;
+
+    return get_identifier_decls(ident);
+}


### PR DESCRIPTION
Two commits:
- rename symbol which required a larger refactor to make sense with two new files.
- add hover, which requires the previous commit. This one also fixes LSP_Hover struct for syntax highlighting and works around ast_print missing handlers for struct/enum/union/#type (those would otherwise render as literal uppercase "STRUCT", "DIRECTIVE_TYPE" etc.)