### PR TITLE
Exit when the editor goes away: quit on stdin EOF, add parent-process watchdog

### DIFF
--- a/server/main.jai
+++ b/server/main.jai
@@ -495,8 +495,15 @@ main :: () {
     init_memory_files();
     defer deinit_memory_files();
 
+    start_parent_watchdog();
+
     while !server.quit {
-        body, success := read_message_from_stdin(,, temp);
+        body, success, closed := read_message_from_stdin(,, temp);
+        if closed {
+            // The editor closed our stdin. Without this we would spin here forever at 100% CPU.
+            log("Input closed, shutting down.");
+            break;
+        }
         if !success {
             log("Failed to read message. Skipping.");
             continue;
@@ -555,4 +562,33 @@ main :: () {
     #import "Windows";
 } else {
     #import "POSIX";
+}
+
+// Parent watchdog.
+//
+// The main thread can be blocked for a long time (e.g. in parse_files_drain), so it can't be trusted to notice
+// that the editor went away. Previously a stuck parse meant jails outlived the editor forever, burning CPU.
+// This thread polls the parent pid and exits as soon as we get re-parented (parent died).
+parent_watchdog_thread: Thread;
+
+start_parent_watchdog :: () {
+    #if OS != .WINDOWS {
+        thread_init(*parent_watchdog_thread, parent_watchdog);
+        thread_start(*parent_watchdog_thread);
+    }
+}
+
+#if OS != .WINDOWS {
+    parent_watchdog :: (thread: *Thread) -> s64 {
+        initial_parent := getppid();
+
+        while true {
+            sleep_milliseconds(1000);
+            if getppid() != initial_parent {
+                log("Parent process % is gone, exiting.", initial_parent);
+                exit(0);
+            }
+        }
+        return 0;
+    }
 }

--- a/server/rpc.jai
+++ b/server/rpc.jai
@@ -64,20 +64,21 @@ parse_header :: (header : string) -> s64, success: bool {
     return nb_bytes, success;
 }
 
-read_message_from_stdin :: () -> string, bool {
+// Returns (body, success, closed). `closed` is true when stdin hit EOF, i.e. the client went away.
+read_message_from_stdin :: () -> string, bool, bool {
     buffer: [0xFFFF]u8;
 
     header_bytes := read_line_from_stdin(buffer);
     if header_bytes <= 0 {
       log_error("The input channel was closed!");
-      return "", false;
+      return "", false, true;
     }
     header := to_string(buffer.data, xx header_bytes);
 
     body_size, success := parse_header(header);
     if !success {
         log_error("Couldnt parse header!");
-        return "", false;
+        return "", false, false;
     }
 
     body_buffer: []u8 = ---;
@@ -86,7 +87,7 @@ read_message_from_stdin :: () -> string, bool {
 
     if read_from_stdin(buffer.data + header.count, 2) < 2 {
       log_error("Couldn't read CRLF!");
-      return "", false;
+      return "", false, false;
     } // @todo: this is somewhat weird
 
     if buffer[header.count+1] != #char "\n" {
@@ -99,12 +100,12 @@ read_message_from_stdin :: () -> string, bool {
 
     if body_read != xx body_size {
         log_error("Expected % bytes, got %!", body_size, body_read);
-        return "", false;
+        return "", false, false;
     }
 
     body := to_string(body_buffer.data, body_buffer.count);
 
-    return body, true;
+    return body, true, false;
 }
 
 send_message :: (data: $T) {


### PR DESCRIPTION
If the editor closed while jails was busy (e.g. stuck parsing), the process was left running forever.

This makes jails exit on stdin EOF, and adds a small watchdog thread that exits if the parent process disappears.

Related: https://github.com/SogoCZE/jai_parser/pull/32